### PR TITLE
Add row of images from webfolder source

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,6 +15,13 @@ module.exports = {
         accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
       },
     },
+    {
+      resolve: `@imgix/gatsby`,
+      options: {
+        domain: "sherwinski-contentful-wf.imgix.net",
+        defaultImgixParams: { auto: ["compress", "format"] },
+      },
+    },
     `gatsby-plugin-image`,
     `gatsby-plugin-postcss`,
   ],

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,25 +4,54 @@ import { ImgixGatsbyImage } from "@imgix/gatsby";
 
 export default function Home({ data }) {
   return (
-    <div class="p-4">
-      <div class="flex flex-wrap">
-        {data.allContentfulBlogPost.edges.map(({ node }) => (
-          <div class="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
-            <p class="text-2xl p-2">{parse(node.title)}</p>
-            <ImgixGatsbyImage
-              src={node.imgUrl}
-              imgixParams={{
-                auto: "format,compress",
-                crop: "faces,edges",
-              }}
-              layout="constrained"
-              width={350}
-              aspectRatio={16 / 9}
-              alt="An imgix-served image from Contentful"
-            />
-            <p class="p-2">{parse(node.description.description)}</p>
-          </div>
-        ))}
+    <div>
+      <div className="p-4">
+        <div className="flex flex-wrap">
+          {data.allContentfulBlogPost.edges.map(({ node }) => (
+            <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
+              <p className="text-2xl p-2">{node.title} with Webfolder</p>
+              <ImgixGatsbyImage
+                src={
+                  `https://sherwinski-contentful-wf.imgix.net/` +
+                  node.heroImage.file.url.split("/").slice(4).join("/")
+                }
+                imgixParams={{
+                  auto: "format,compress",
+                  crop: "faces,edges",
+                }}
+                layout="constrained"
+                width={350}
+                aspectRatio={16 / 9}
+                sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
+                alt="An imgix-served image from Contentful"
+              />
+              <p className="p-2">{node.description.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="p-4">
+        <div className="flex flex-wrap">
+          {data.allContentfulBlogPost.edges.map(({ node }) => (
+            <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
+              <p className="text-2xl p-2">{node.title} with imgix-contentful</p>
+              <ImgixGatsbyImage
+                src={node.imgUrl}
+                imgixParams={{
+                  auto: "format,compress",
+                  crop: "faces,edges",
+                }}
+                layout="constrained"
+                width={350}
+                aspectRatio={16 / 9}
+                sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
+                alt="An imgix-served image from Contentful"
+              />
+              <p className="p-2">{node.description.description}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { graphql } from "gatsby";
 import { ImgixGatsbyImage } from "@imgix/gatsby";
-import parse from "html-react-parser";
 
 export default function Home({ data }) {
   return (
@@ -38,6 +37,11 @@ export const query = graphql`
           title
           description {
             description
+          }
+          heroImage {
+            file {
+              url
+            }
           }
         }
       }


### PR DESCRIPTION
The webfolder source points to `https://images.ctfassets.net/{space_id}`. The rest of the file path is extracted (albeit in a hacky way) to create a fully qualified URL, which is passed through to the imgix component.